### PR TITLE
Better DELETE SQL queries for `/games` and `/teams` routes

### DIFF
--- a/routes/games.js
+++ b/routes/games.js
@@ -122,8 +122,11 @@ module.exports = app => {
         const gameId = req.params.gameId
         const sqlQuery = `
             DELETE
-                FROM games
-                WHERE game_id = ${gameId}
+                r, t, g
+                FROM rounds r
+                JOIN teams t ON t.team_id = r.team_id
+                JOIN games g ON g.game_id = t.game_id
+                WHERE g.game_id = ${gameId}
         `
         try {
             await queryDatabase(sqlQuery)

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -128,8 +128,10 @@ module.exports = app => {
         const teamId = req.params.teamId
         const sqlQuery = `
             DELETE
-                FROM teams
-                WHERE team_id = ${teamId}
+                r, t
+                FROM rounds r
+                JOIN teams t ON t.team_id = r.team_id
+                WHERE t.team_id = ${teamId}
         `
         try {
             await queryDatabase(sqlQuery)


### PR DESCRIPTION
If accepted, this PR will cause DELETE actions to delete not only the specified game/team, but also associated teams/scores.